### PR TITLE
texcount: add page

### DIFF
--- a/pages/common/texcount.md
+++ b/pages/common/texcount.md
@@ -1,0 +1,16 @@
+# texcount
+
+> Count words in TeX documents ommiting macros
+> More information: <https://app.uio.no/ifi/texcount/index.html>.
+
+- Count words in one TeX file:
+`texcount path/to/file`
+
+- Count words in document and subdocuments built with \input or \include:
+`texcount -merge file`
+
+- Count words in document and subdocuments list each file extra:
+`texcount -inc file`
+
+- Count words with verbose output:
+`texcount -v path/to/file`


### PR DESCRIPTION
texcount is a command line tool that comes with TeX Live preinstalled. It counts words in TeX files or TeX document structures while omitting macros
